### PR TITLE
rcode is 5 bits wide

### DIFF
--- a/lib/dnspacket.js
+++ b/lib/dnspacket.js
@@ -28,7 +28,7 @@ function parseFlags(val, packet) {
   packet.header.res1 = (val & 0x40) >> 6;
   packet.header.res2 = (val & 0x20) >> 5;
   packet.header.res3 = (val & 0x10) >> 4;
-  packet.header.rcode = (val & 0xF);
+  packet.header.rcode = (val & 0x1F);
 }
 
 function parseHeader(consumer, packet) {


### PR DESCRIPTION
`rcode` should be 5 bits wide, not 4. Thus the mask is 0x1F, not 0xF.

See http://www.zytrax.com/books/dns/ch15/#rcode

See https://github.com/tjfontaine/native-dns-packet/pull/34